### PR TITLE
Add Any type support for shape

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Each of `shape`, `dtype`, `layout`, `details` are optional.
   - A `str: ...` pair, in which case the multiple dimensions corresponding to `...` will be bound to the name specified by `str`, and again checked for consistency between arguments.
   - `None`, which when used in conjunction with `is_named` below, indicates a dimension that must _not_ have a name in the sense of [named tensors](https://pytorch.org/docs/stable/named_tensor.html).
   - A `None: int` pair, combining both `None` and `int` behaviour. (Just a `None` on its own is equivalent to `None: -1`.)
+  - A `typing.Any`: Any size is allowed for this dimension (equivalent to `-1`).
   - Any tuple of the above. For example.`TensorType["batch": ..., "length": 10, "channels", -1]`. If you just want to specify the number of dimensions then use for example `TensorType[-1, -1, -1]` for a three-dimensional tensor.
 - The `dtype` argument can be any of:
   - `torch.float32`, `torch.float64` etc.

--- a/test/test_shape.py
+++ b/test/test_shape.py
@@ -235,7 +235,7 @@ def test_any_dim():
         pass
 
     @typeguard.typechecked
-    def _m14any_dim_checker(x: TensorType[Any, 4, Any]):
+    def _any4any_dim_checker(x: TensorType[Any, 4, Any]):
         pass
 
     x = torch.rand(3)
@@ -248,7 +248,7 @@ def test_any_dim():
     with pytest.raises(TypeError):
         _34any_dim_checker(x)
     with pytest.raises(TypeError):
-        _m14any_dim_checker(x)
+        _any4any_dim_checker(x)
 
     x = torch.rand((3, 4))
     _3any_dim_checker(x)
@@ -265,10 +265,10 @@ def test_any_dim():
 
     x = torch.rand((3, 4, 5))
     _34any_dim_checker(x)
-    _m14any_dim_checker(x)
+    _any4any_dim_checker(x)
 
     x = torch.rand((3, 5, 5))
     with pytest.raises(TypeError):
-        x = _m14any_dim_checker(x)
+        x = _any4any_dim_checker(x)
     with pytest.raises(TypeError):
         _34any_dim_checker(x)

--- a/test/test_shape.py
+++ b/test/test_shape.py
@@ -1,4 +1,5 @@
 import pytest
+from typing import Any
 import torch
 from torchtyping import TensorType
 import typeguard
@@ -214,3 +215,60 @@ def test_int_str_dim():
         _abm1_dim_checker(x)
     with pytest.raises(TypeError):
         _m1bm1_dim_checker(x)
+
+
+def test_any_dim():
+    @typeguard.typechecked
+    def _3any_dim_checker(x: TensorType[3, Any]):
+        pass
+
+    @typeguard.typechecked
+    def _any4_dim_checker(x: TensorType[Any, 4]):
+        pass
+
+    @typeguard.typechecked
+    def _anyany_dim_checker(x: TensorType[Any, Any]):
+        pass
+
+    @typeguard.typechecked
+    def _34any_dim_checker(x: TensorType[3, 4, Any]):
+        pass
+
+    @typeguard.typechecked
+    def _m14any_dim_checker(x: TensorType[Any, 4, Any]):
+        pass
+
+    x = torch.rand(3)
+    with pytest.raises(TypeError):
+        _3any_dim_checker(x)
+    with pytest.raises(TypeError):
+        _any4_dim_checker(x)
+    with pytest.raises(TypeError):
+        _anyany_dim_checker(x)
+    with pytest.raises(TypeError):
+        _34any_dim_checker(x)
+    with pytest.raises(TypeError):
+        _m14any_dim_checker(x)
+
+    x = torch.rand((3, 4))
+    _3any_dim_checker(x)
+    _any4_dim_checker(x)
+    _anyany_dim_checker(x)
+
+    x = torch.rand((4, 5))
+    with pytest.raises(TypeError):
+        _any4_dim_checker(x)
+
+    x = torch.rand(4, 5)
+    with pytest.raises(TypeError):
+        _3any_dim_checker(x)
+
+    x = torch.rand((3, 4, 5))
+    _34any_dim_checker(x)
+    _m14any_dim_checker(x)
+
+    x = torch.rand((3, 5, 5))
+    with pytest.raises(TypeError):
+        x = _m14any_dim_checker(x)
+    with pytest.raises(TypeError):
+        _34any_dim_checker(x)

--- a/torchtyping/tensor_type.py
+++ b/torchtyping/tensor_type.py
@@ -88,11 +88,7 @@ class TensorType(metaclass=_TensorTypeMeta):
         layouts = []
         details = []
         for item_i in item:
-            if (
-                isinstance(item_i, (int, str, slice))
-                or item_i in (None, ...)
-                or item_i is Any
-            ):
+            if isinstance(item_i, (int, str, slice)) or item_i in (None, ..., Any):
                 item_i = cls._convert_shape_element(item_i)
                 if item_i.size is ...:
                     # Supporting an arbitrary number of Ellipsis in arbitrary

--- a/torchtyping/tensor_type.py
+++ b/torchtyping/tensor_type.py
@@ -56,6 +56,8 @@ class TensorType(metaclass=_TensorTypeMeta):
             return _Dim(name=item_i.start, size=item_i.stop)
         elif item_i is ...:
             return _Dim(name=_no_name, size=...)
+        elif item_i is Any:
+            return _Dim(name=_no_name, size=-1)
         else:
             cls._type_error(item_i)
 
@@ -86,7 +88,11 @@ class TensorType(metaclass=_TensorTypeMeta):
         layouts = []
         details = []
         for item_i in item:
-            if isinstance(item_i, (int, str, slice)) or item_i in (None, ...):
+            if (
+                isinstance(item_i, (int, str, slice))
+                or item_i in (None, ...)
+                or item_i is Any
+            ):
                 item_i = cls._convert_shape_element(item_i)
                 if item_i.size is ...:
                     # Supporting an arbitrary number of Ellipsis in arbitrary


### PR DESCRIPTION
We can specify the arbitrary shape of a dimension using the Any type.
Example: `any_tensor = TensorType[3, 3, Any, torch.float32]`

I do not include the tests, to be honest, I am a bit lost on all the tests that you want. Could you clarify them for me @patrick-kidger ? 

So that I can do them in the next commit.

Edit: I guess a `test/test_any.py` and a function `test_any_dim` in `test/test_shape.py`