### PR TITLE
TensorType now inherits from torch.Tensor so that IDE lookup+error messages work

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,9 +3,9 @@ repos:
     rev: stable
     hooks:
     - id: black
-      language_version: python3.8
+      language_version: python3.9
 
--   repo: https://gitlab.com/pycqa/flake8
-    rev: 3.8.4
+-   repo: https://github.com/pycqa/flake8
+    rev: 3.9.2
     hooks:
     - id: flake8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+**0.1.3**
+
+`TensorType` now inherits from `torch.Tensor` so that IDE lookup+error messages work as expected.  
+Updated pre-commit hooks. These were failing for some reason.
+
 **0.1.2**
 
 Added support for `str: str` pairs and `None: str` pairs.

--- a/torchtyping/__init__.py
+++ b/torchtyping/__init__.py
@@ -10,4 +10,4 @@ from .tensor_details import (
 from .tensor_type import TensorType
 from .typechecker import patch_typeguard
 
-__version__ = "0.1.2"
+__version__ = "0.1.3"

--- a/torchtyping/tensor_type.py
+++ b/torchtyping/tensor_type.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
-import sys
 
+import sys
 import torch
 
 from .tensor_details import (
@@ -34,9 +34,7 @@ class _TensorTypeMeta(type):
         return isinstance(obj, cls.base_cls)
 
 
-class TensorType(metaclass=_TensorTypeMeta):
-    base_cls = torch.Tensor
-
+class TensorTypeMixin(metaclass=_TensorTypeMeta):
     def __new__(cls, *args, **kwargs) -> NoReturn:
         raise RuntimeError(f"Class {cls.__name__} cannot be instantiated.")
 
@@ -171,3 +169,9 @@ class TensorType(metaclass=_TensorTypeMeta):
                 {"__torchtyping__": True, "details": details, "cls_name": cls.__name__}
             ),
         ]
+
+
+# Inherit from torch.Tensor so that IDEs are happy to find methods on functions
+# annotated as TensorTypes.
+class TensorType(torch.Tensor, TensorTypeMixin):
+    base_cls = torch.Tensor


### PR DESCRIPTION
This should close #18.

Also updated some pre-commit hooks that were giving me trouble for some reason.