### PR TITLE
Fix metaclass conflict for torch 1.9

### DIFF
--- a/torchtyping/tensor_type.py
+++ b/torchtyping/tensor_type.py
@@ -29,7 +29,7 @@ _AnnotatedType = type(Annotated[torch.Tensor, ...])
 
 
 # For use when we have a plain TensorType, without any [].
-class _TensorTypeMeta(type):
+class _TensorTypeMeta(type(torch.Tensor)):
     def __instancecheck__(cls, obj: Any) -> bool:
         return isinstance(obj, cls.base_cls)
 


### PR DESCRIPTION
In torch 1.9 a custom metaclass was added to `torch.Tensor` class, causing metaclass conflict while subclassing from `torch.Tensor` and `TensorTypeMixin`. This small fix seems to resolve the issue.