### PR TITLE
`copy.deepcopy` cannot copy `torchtyping.utils.frozendict` objects

### DIFF
--- a/torchtyping/utils.py
+++ b/torchtyping/utils.py
@@ -15,3 +15,9 @@ class frozendict(dict):
 
     def __hash__(self):
         return self._hash
+
+    def __copy__(self):
+        return self
+
+    def __deepcopy__(self, memo):
+        return self


### PR DESCRIPTION
`copy.deepcopy` is used in some training loops to save a copy of the model parameters that has the best validation loss. Currently, the following code gives an error:

```python
import copy
from torchtyping import TensorType
copy.deepcopy(TensorType["batch", "embedding"])
```

```
TypeError: __setitem__() takes 2 positional arguments but 3 were given
```

Instead, copying the dictionary should just return the dictionary unaltered. Since it cannot be changed, the copy does nothing.