### PR TITLE
Tensor duck

### DIFF
--- a/test/test_torchlike.py
+++ b/test/test_torchlike.py
@@ -1,0 +1,61 @@
+# Test ability to type-check user defined classes which have a "torch-like" interface
+# The required interface is defined as the protocol TensorLike in tensor_details.py
+
+from __future__ import annotations
+import pytest
+import torch
+from torch import rand
+
+from torchtyping import TensorType, TensorTypeMixin
+from typeguard import typechecked
+
+
+# New class that supports the tensor-like interface
+class MyTensor:
+    def __init__(self, tensor: torch.Tensor = torch.zeros(2, 3)):
+        self.tensor = tensor
+        self.dtype = self.tensor.dtype
+        self.layout = "something special"
+        self.names = self.tensor.names
+        self.shape = self.tensor.shape
+
+    def is_floating_point(self) -> bool:
+        return self.dtype == torch.float32
+
+    # Add tensors and take the mean over the last dimension
+    # Output drops the last dimension
+    def __add__(self, o: torch.Tensor) -> MyTensor:
+        res = self.tensor + o
+        res_reduced = torch.mean(res, -1)
+        res_myt = MyTensor(res_reduced)
+        return res_myt
+
+
+# Create a type corresponding to the new class
+class MyTensorType(MyTensor, TensorTypeMixin):
+    base_cls = MyTensor
+
+
+def test_my_tensor1():
+    @typechecked
+    def func(x: MyTensorType["x", "y"], y: TensorType["x", "y"]) -> MyTensorType["x"]:
+        return x + y
+
+    @typechecked
+    def bad_func_spec(x: MyTensorType["x", "y"], y: TensorType["x", "y"]) -> MyTensorType["x", "y"]:
+        return x + y
+
+    my_t: MyTensor = MyTensor()
+    func(my_t, rand((2, 3)))
+
+    # Incorrect input dimensions for x
+    with pytest.raises(TypeError):
+        func(MyTensor(rand(1)), rand((2, 3)))
+
+    # Incorrect input dimensions for y
+    with pytest.raises(TypeError):
+        func(my_t, rand(1))
+
+    # Incorrect spec for return dimensions
+    with pytest.raises(TypeError):
+        bad_func_spec(my_t, rand((2, 3)))

--- a/test/test_torchlike.py
+++ b/test/test_torchlike.py
@@ -36,13 +36,19 @@ class MyTensorType(MyTensor, TensorTypeMixin):
     base_cls = MyTensor
 
 
+# make flake8 happy
+x = y = None
+
+
 def test_my_tensor1():
     @typechecked
     def func(x: MyTensorType["x", "y"], y: TensorType["x", "y"]) -> MyTensorType["x"]:
         return x + y
 
     @typechecked
-    def bad_func_spec(x: MyTensorType["x", "y"], y: TensorType["x", "y"]) -> MyTensorType["x", "y"]:
+    def bad_func_spec(
+        x: MyTensorType["x", "y"], y: TensorType["x", "y"]
+    ) -> MyTensorType["x", "y"]:
         return x + y
 
     my_t: MyTensor = MyTensor()

--- a/torchtyping/__init__.py
+++ b/torchtyping/__init__.py
@@ -7,7 +7,7 @@ from .tensor_details import (
     TensorDetail,
 )
 
-from .tensor_type import TensorType
+from .tensor_type import TensorType, TensorTypeMixin
 from .typechecker import patch_typeguard
 
 __version__ = "0.1.4"

--- a/torchtyping/tensor_details.py
+++ b/torchtyping/tensor_details.py
@@ -17,6 +17,7 @@ class TensorLike(Protocol):
     # We assume the class has a default constructor
     def __init__(self):
         pass
+
     @property
     def dtype(self) -> torch.dtype:
         pass
@@ -48,8 +49,6 @@ class MyTensor:
 
     def is_floating_point(self):
         return self.dtype == torch.float32
-
-
 
 
 class TensorDetail(metaclass=abc.ABCMeta):

--- a/torchtyping/tensor_details.py
+++ b/torchtyping/tensor_details.py
@@ -4,10 +4,52 @@ import abc
 import collections
 import torch
 
-from typing import Optional, Union
+from typing import Optional, Union, runtime_checkable, Protocol, Tuple, Any
 
 
 ellipsis = type(...)
+
+
+# Define a Protocol (PEP 544) class to represent "tensor-like" objects
+# These are objects which support the interface given below
+@runtime_checkable
+class TensorLike(Protocol):
+    # We assume the class has a default constructor
+    def __init__(self):
+        pass
+    @property
+    def dtype(self) -> torch.dtype:
+        pass
+
+    # leave the layout definition open because tensor-like classes are likely
+    # to extend it with new storage types
+    @property
+    def layout(self) -> Any:
+        pass
+
+    @property
+    def names(self) -> Tuple[str, ...]:
+        pass
+
+    @property
+    def shape(self) -> Tuple[int, ...]:
+        pass
+
+    def is_floating_point(self) -> bool:
+        pass
+
+
+class MyTensor:
+    def __init__(self):
+        self.dtype = torch.float32
+        self.layout = "very special"
+        self.names = (None, None)
+        self.shape = (1, 1)
+
+    def is_floating_point(self):
+        return self.dtype == torch.float32
+
+
 
 
 class TensorDetail(metaclass=abc.ABCMeta):
@@ -16,12 +58,12 @@ class TensorDetail(metaclass=abc.ABCMeta):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def check(self, tensor: torch.Tensor) -> bool:
+    def check(self, tensor: TensorLike) -> bool:
         raise NotImplementedError
 
     @classmethod
     @abc.abstractmethod
-    def tensor_repr(cls, tensor: torch.Tensor) -> str:
+    def tensor_repr(cls, tensor: TensorLike) -> str:
         raise NotImplementedError
 
 
@@ -69,7 +111,7 @@ class ShapeDetail(TensorDetail):
             out += ", is_named"
         return out
 
-    def check(self, tensor: torch.Tensor) -> bool:
+    def check(self, tensor: TensorLike) -> bool:
         self_names = [self_dim.name for self_dim in self.dims]
         self_shape = [self_dim.size for self_dim in self.dims]
 
@@ -103,7 +145,7 @@ class ShapeDetail(TensorDetail):
         return True
 
     @classmethod
-    def tensor_repr(cls, tensor: torch.Tensor) -> str:
+    def tensor_repr(cls, tensor: TensorLike) -> str:
         dims = []
         check_names = any(name is not None for name in tensor.names)
         for name, size in zip(tensor.names, tensor.shape):
@@ -133,11 +175,11 @@ class DtypeDetail(TensorDetail):
     def __repr__(self) -> str:
         return repr(self.dtype)
 
-    def check(self, tensor: torch.Tensor) -> bool:
+    def check(self, tensor: TensorLike) -> bool:
         return self.dtype == tensor.dtype
 
     @classmethod
-    def tensor_repr(cls, tensor: torch.Tensor) -> str:
+    def tensor_repr(cls, tensor: TensorLike) -> str:
         return repr(cls(dtype=tensor.dtype))
 
 
@@ -149,11 +191,11 @@ class LayoutDetail(TensorDetail):
     def __repr__(self) -> str:
         return repr(self.layout)
 
-    def check(self, tensor: torch.Tensor) -> bool:
+    def check(self, tensor: TensorLike) -> bool:
         return self.layout == tensor.layout
 
     @classmethod
-    def tensor_repr(cls, tensor: torch.Tensor) -> str:
+    def tensor_repr(cls, tensor: TensorLike) -> str:
         return repr(cls(layout=tensor.layout))
 
 
@@ -161,11 +203,11 @@ class _FloatDetail(TensorDetail):
     def __repr__(self) -> str:
         return "is_float"
 
-    def check(self, tensor: torch.Tensor) -> bool:
+    def check(self, tensor: TensorLike) -> bool:
         return tensor.is_floating_point()
 
     @classmethod
-    def tensor_repr(cls, tensor: torch.Tensor) -> str:
+    def tensor_repr(cls, tensor: TensorLike) -> str:
         return "is_float" if tensor.is_floating_point() else ""
 
 
@@ -177,11 +219,11 @@ class _NamedTensorDetail(TensorDetail):
     def __repr__(self) -> str:
         raise RuntimeError
 
-    def check(self, tensor: torch.Tensor) -> bool:
+    def check(self, tensor: TensorLike) -> bool:
         raise RuntimeError
 
     @classmethod
-    def tensor_repr(cls, tensor: torch.Tensor) -> str:
+    def tensor_repr(cls, tensor: TensorLike) -> str:
         raise RuntimeError
 
 

--- a/torchtyping/tensor_type.py
+++ b/torchtyping/tensor_type.py
@@ -11,6 +11,7 @@ from .tensor_details import (
     LayoutDetail,
     ShapeDetail,
     TensorDetail,
+    TensorLike,
 )
 from .utils import frozendict
 
@@ -25,7 +26,7 @@ else:
     from typing_extensions import Annotated
 
 # Not Type[Annotated...] as we want to use this in instance checks.
-_AnnotatedType = type(Annotated[torch.Tensor, ...])
+_AnnotatedType = type(Annotated[TensorLike, ...])
 
 
 # For use when we have a plain TensorType, without any [].

--- a/torchtyping/typechecker.py
+++ b/torchtyping/typechecker.py
@@ -1,6 +1,5 @@
 import inspect
 import sys
-import torch
 import typeguard
 
 from .tensor_details import _Dim, _no_name, ShapeDetail, TensorLike
@@ -11,9 +10,9 @@ from typing import Any, Dict, List, Tuple
 # get_args is available in python version 3.8
 # get_type_hints with include_extras parameter is available in 3.9 PEP 593.
 if sys.version_info >= (3, 9):
-    from typing import get_type_hints, get_args, Type
+    from typing import get_type_hints, get_args
 else:
-    from typing_extensions import get_type_hints, get_args, Type
+    from typing_extensions import get_type_hints, get_args
 
 
 # TYPEGUARD PATCHER


### PR DESCRIPTION
As promised, here is the PR to upgrade the library to define a 'torch-like' protocol and use that for the base type rather than using torch.Tensor directly.  This lets users perform dimension checking on classes that support a Tensor interface but do not directly inherit from torch.Tensor.  I think the change is fairly clear-cut, I have added a test case to demonstrate and verify that dimensions are actually checked.
The only question I have is about the change to line 304 in typechecker.py (the last change below).
Is this test really necessary?
I had to change it to use default construction because protocols don't support isinstance if they have properties.