### PR TITLE
Fix typeguard upper bound

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ user_python_version = sys.version_info
 
 python_requires = ">=3.7.0"
 
-install_requires = ["torch>=1.7.0", "typeguard>=2.11.1"]
+install_requires = ["torch>=1.7.0", "typeguard>=2.11.1,<3"]
 
 if user_python_version < (3, 9):
     install_requires += ["typing_extensions==3.7.4.3"]


### PR DESCRIPTION
The current package breaks on `typeguard>=3` due to the following error:

```python
  File "/.../test2.py", line 13, in <module>
    patch_typeguard()  # use before @typechecked
  File "/.../python3.10/site-packages/torchtyping/typechecker.py", line 271, in patch_typeguard
    class _CallMemo(typeguard._CallMemo):
  File "/.../python3.10/site-packages/typeguard/__init__.py", line 42, in __getattr__
    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
AttributeError: module 'typeguard' has no attribute '_CallMemo'. Did you mean: 'CallMemo'?
```

So this just limits the typeguard install to `<3` which fixes things. It looks like a few functions need to be rewritten on `>=3` so this is a simple band-aid fix.

(I understand this package isn't actively maintained, but until https://github.com/google/jaxtyping/issues/6 is closed, I find this package a bit more useful, even though you mention the `patch_typeguard` felt a bit hacky 😄)